### PR TITLE
Add RBAC deamonset clusterrole and clusterrolebinding

### DIFF
--- a/resources/authorization/cmk-rbac-rules.yaml
+++ b/resources/authorization/cmk-rbac-rules.yaml
@@ -10,6 +10,28 @@ rules:
   resources: ["thirdpartyresources", "thirdpartyresources.extensions"]
   verbs: ["*"]
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cmk-daemonset-controller
+rules:
+- apiGroups: ["extensions"]
+  resources: ["daemonsets", "daemonsets.extensions"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cmk-role-binding-daemonset
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cmk-daemonset-controller
+subjects:
+- kind: ServiceAccount
+  name: cmk-serviceaccount
+  namespace: default
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
I've tried start cmk using cmk cluster-init and pod not starting. I added new RBAC clusterrole with resources "daemonsets.extensions" from apiGroups "extensions" and new clusterrolebinding. That was enough to start pod correctly.