### PR TITLE
Network exceptions handling and api calls timeouts

### DIFF
--- a/intel/config.py
+++ b/intel/config.py
@@ -21,9 +21,10 @@ import threading
 import _thread
 
 
-# CMK_LOCK_TIMEOUT is interpreted as seconds.
 ENV_LOCK_TIMEOUT = "CMK_LOCK_TIMEOUT"
+# timeouts are in seconds
 DEFAULT_LOCK_TIMEOUT = 30
+API_CALL_TIMEOUT = 5
 
 
 def max_lock_seconds():

--- a/intel/custom_resource.py
+++ b/intel/custom_resource.py
@@ -17,6 +17,7 @@ import time
 
 from http import client
 from kubernetes.client.rest import ApiException as K8sApiException
+from .config import API_CALL_TIMEOUT
 from .util import ldh_convert_check
 
 # Example usage:
@@ -96,7 +97,8 @@ class CustomResourceDefinitionType:
                 'POST',
                 self.header_params,
                 body=self.body,
-                auth_settings=self.auth_settings)
+                auth_settings=self.auth_settings,
+                _request_timeout=API_CALL_TIMEOUT)
 
         except K8sApiException as e:
             if e.status != client.CONFLICT:
@@ -115,7 +117,8 @@ class CustomResourceDefinitionType:
                 self.resource_path_crd_type,
                 'GET',
                 self.header_params,
-                auth_settings=self.auth_settings)
+                auth_settings=self.auth_settings,
+                _request_timeout=API_CALL_TIMEOUT)
 
         except K8sApiException as e:
             if e.status == client.CONFLICT or e.status == client.NOT_FOUND:
@@ -136,7 +139,8 @@ class CustomResourceDefinitionType:
                 self.resource_path_crd_type,
                 'DELETE',
                 self.header_params,
-                auth_settings=self.auth_settings)
+                auth_settings=self.auth_settings,
+                _request_timeout=API_CALL_TIMEOUT)
 
 
 class CustomResourceDefinition:
@@ -181,7 +185,8 @@ class CustomResourceDefinition:
             resource_path,
             'DELETE',
             self.resource_type.header_params,
-            auth_settings=self.resource_type.auth_settings)
+            auth_settings=self.resource_type.auth_settings,
+            _request_timeout=API_CALL_TIMEOUT)
 
     def create(self):
         """Create custom object"""
@@ -190,7 +195,8 @@ class CustomResourceDefinition:
             'POST',
             self.resource_type.header_params,
             body=self.body,
-            auth_settings=self.resource_type.auth_settings)
+            auth_settings=self.resource_type.auth_settings,
+            _request_timeout=API_CALL_TIMEOUT)
 
     def save(self):
         """Save custom object if not exists"""

--- a/intel/third_party.py
+++ b/intel/third_party.py
@@ -18,6 +18,7 @@ import time
 
 from http import client
 from kubernetes.client.rest import ApiException as K8sApiException
+from .config import API_CALL_TIMEOUT
 from .util import ldh_convert_check
 
 
@@ -92,7 +93,8 @@ class ThirdPartyResourceType:
                 resource_path,
                 'GET',
                 header_params,
-                auth_settings=auth_settings)
+                auth_settings=auth_settings,
+                _request_timeout=API_CALL_TIMEOUT)
 
         except K8sApiException as e:
             if e.status == client.CONFLICT or e.status == client.NOT_FOUND:
@@ -148,7 +150,8 @@ class ThirdPartyResource:
             resource_path,
             'DELETE',
             self.header_params,
-            auth_settings=self.auth_settings)
+            auth_settings=self.auth_settings,
+            _request_timeout=API_CALL_TIMEOUT)
 
     def create(self):
         resource_path = "/".join([
@@ -166,7 +169,8 @@ class ThirdPartyResource:
             'POST',
             self.header_params,
             body=self.body,
-            auth_settings=self.auth_settings)
+            auth_settings=self.auth_settings,
+            _request_timeout=API_CALL_TIMEOUT)
 
     def save(self):
         try:

--- a/tests/unit/test_k8s.py
+++ b/tests/unit/test_k8s.py
@@ -175,7 +175,7 @@ def test_k8s_get_namespaces():
         assert len(called_methods) == 1
         assert called_methods[0][0] == "list_namespace"
         assert len(called_methods[0][1]) == 0
-        assert len(called_methods[0][2]) == 0
+        assert len(called_methods[0][2]) == 1
 
 
 def test_k8s_get_kubelet_version():


### PR DESCRIPTION
This PR adds handling of network exceptions to `nodereport` and `reconcile` pods, avoiding pod restarts during network outage.
Additionally, request timeouts were added for every Kubernetes API call, as default timeouts take too much time.